### PR TITLE
changed library for server timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express-handlebars": "^5.2.0",
     "express-session": "^1.17.1",
     "moment": "^2.30.1",
+    "moment-timezone": "^0.5.45",
     "pg": "^8.11.3",
     "sequelize": "^6.33.0"
   }

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const session = require('express-session');
 const exphbs = require('express-handlebars');
 const routes = require('./controllers');
 const helpers = require('./utils/helpers');
+const moment = require('moment-timezone');
 
 const sequelize = require('./config/connection');
 const SequelizeStore = require('connect-session-sequelize')(session.Store);

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,8 +1,9 @@
-const moment = require('moment');
+const moment = require('moment-timezone');
 
 module.exports = {
   formatDate: function(date, format) {
     if (!date) return '';
-    return moment(date).format(format);
+    // Set the timezone to Sydney, Australia
+    return moment(date).tz('Australia/Sydney').format(format);
   }
 };


### PR DESCRIPTION
- Replaced Moment with subsidiary moment-timezone

This will set the server's perception of time to Sydney, Australia to match presentation audience.